### PR TITLE
Enable replacement of PyTorch inline op & suspend const propagation f…

### DIFF
--- a/torch_glow/src/GlowFuser.cpp
+++ b/torch_glow/src/GlowFuser.cpp
@@ -26,6 +26,7 @@
 #include <torch/csrc/jit/passes/common_subexpression_elimination.h>
 #include <torch/csrc/jit/passes/dead_code_elimination.h>
 #include <torch/csrc/jit/passes/inliner.h>
+#include <torch/csrc/jit/passes/remove_mutation.h>
 #include <torch/csrc/jit/passes/subgraph_rewrite.h>
 #include <torch/csrc/jit/passes/utils/subgraph_utils.h>
 #include <torch/csrc/jit/runtime/custom_operator.h>
@@ -305,6 +306,10 @@ void glowCustomFuseImpl(std::shared_ptr<torch::jit::Graph> graph,
   std::unordered_set<const torch::jit::Node *> indexBlacklistedNodes;
 
   size_t i = 0;
+  if (settings.enableRemoveMutation) {
+    RemoveListMutation(graph);
+    RemoveTensorMutation(graph);
+  }
   for (const torch::jit::Node *node : graph->nodes()) {
     if (settings.fusionStartIndex >= 0 && i < settings.fusionStartIndex) {
       indexBlacklistedNodes.insert(node);

--- a/torch_glow/src/PyTorchCommon.h
+++ b/torch_glow/src/PyTorchCommon.h
@@ -114,6 +114,9 @@ public:
   /// Enable tracing inside of Glow.
   bool enableGlowTracing = false;
 
+  /// Enable the auto removal of muation in JIT graph, i.e, inline ops.
+  bool enableRemoveMutation = false;
+
   /// Number of traces per json trace file dump.
   size_t numTracesPerDump = 1;
 

--- a/torch_glow/src/binding.cpp
+++ b/torch_glow/src/binding.cpp
@@ -106,6 +106,14 @@ PYBIND11_MODULE(_torch_glow, m) {
   m.def("enable_glow_tracing",
         []() { getPyTorchLoaderSettings().enableGlowTracing = true; });
 
+  // Enable the auto removal of mutation in JIT graph, i.e, inline ops.
+  m.def("enable_remove_mutation",
+        []() { getPyTorchLoaderSettings().enableRemoveMutation = true; });
+
+  // Disable the auto removal of mutation in JIT graph
+  m.def("disable_remove_mutation",
+        []() { getPyTorchLoaderSettings().enableRemoveMutation = false; });
+
   /// Set the number of traces to dump per trace file.
   m.def("set_num_traces_per_dump", [](size_t numTracesPerDump) {
     getPyTorchLoaderSettings().numTracesPerDump = numTracesPerDump;


### PR DESCRIPTION
…or ReshapeNode. (#4859)

Summary:
Pull Request resolved: https://github.com/pytorch/glow/pull/4859

In order to run NLP model again, we would like to enable these two functionalities.
the ReshapNode is still in investigation why it crashed when doing const propagation, but diable it can make sure we are unblocked.

Reviewed By: jackm321

Differential Revision: D23246042

fbshipit-source-id: f99b46985a77c410f3cba0794ee8d39ff7c0c714

Summary:

Documentation:

[Optional Fixes #issue]

Test Plan:

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
